### PR TITLE
fix(security): Snyk remediation + SAST triage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a official Python runtime as a parent image
-FROM python:3.12-slim
+FROM python:3.12-alpine
 
 # Set the working directory in the container
 WORKDIR /usr/src/app


### PR DESCRIPTION
## Remediação Snyk — datacosmos-br/OdooConnectorAPI

Derivado do scan Snyk da org Datacosmos (dump 2026-08-06). **1 arquivo(s) alterado(s)**.

### O que entra

- **Upgrades de dependência** com `fixed_in` disponível, versões verificadas nos registries.
- **Imagens base** migradas conforme `docker.baseImageRemediation` do Snyk, quando aplicável. Os pacotes de SO reportados são `isUpgradable=false` / `isPatchable=false` / sem `nearestFixedInVersion` — não há patch upstream, e nem `apt-get upgrade` nem pin por digest reduzem a contagem (verificado com `snyk container test`).
- **`go.mod`**: diretivas `go` e `toolchain` elevadas quando há CVE de stdlib. A diretiva `toolchain` fixava a versão vulnerável — elevar só `go` não bastaria.
- **`docs/security/snyk-sast-triage.md`**: inventário SAST com arquivo, linha e CWE por achado, para triagem manual. Sem alteração de código.


---

> **DRAFT — remediação declarada, não validada**
>
> | verificado | não verificado |
> |---|---|
> | versões existem nos registries | build compila |
> | imagens de destino: `snyk container test` = 0 vulns | testes passam |
> | manifestos com sintaxe válida | runtime funciona |
>
> **Riscos**: alpine usa musl em vez de glibc (wheels Python com extensões C, cgo, busybox vs coreutils GNU); saltos major podem exigir ajuste de código.
>
> Sai de draft após a CI ficar verde.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Docker base image from `python:3.12-slim` to `python:3.12-alpine` to remediate Snyk-reported vulnerabilities and reduce image size.

- **Migration**
  - Alpine uses musl; Python packages with C extensions may need build deps.
  - If builds fail, add `apk add --no-cache build-base musl-dev libffi-dev openssl-dev` or use musl-compatible wheels.

<sup>Written for commit bb7d13f4788749144cc049bc404e9a88609f9017. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datacosmos-br/OdooConnectorAPI/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

